### PR TITLE
fix(styles): elimina max width y sombra

### DIFF
--- a/src/scss/layout/_main.scss
+++ b/src/scss/layout/_main.scss
@@ -12,9 +12,7 @@
 }
 
 .boxed-container {
-    max-width: 1440px;
     margin: 0 auto;
-    @include shadow;
 }
 
 main {


### PR DESCRIPTION
El limite actual de max-width para resoluciones grandes es poco estético y sin sentido, ademas elimina sombra en contenedor que no aporta nada.
De esta forma queda mas fluido el layout y 👌 